### PR TITLE
Modified MMSD workflow to accommodate new rules/data

### DIFF
--- a/3_filter.yml
+++ b/3_filter.yml
@@ -16,7 +16,7 @@ targets:
       - summary_flow
   
   summary_sites: 
-    command: summarize_sites(sample_data, raw_site, min.samples = 400) 
+    command: summarize_sites(sample_data, raw_site) 
     
   summary_flow:
     command: summarize_flow(summary_sites)

--- a/3_filter/src/summarize_flow.R
+++ b/3_filter/src/summarize_flow.R
@@ -3,7 +3,10 @@ library(dplyr)
 summarize_flow <- function(summary.samples) {
   
   summary.flow <- summary.samples %>%
-    group_by(siteID) %>%
+    select(-siteID) %>%
+    gather(siteID, site_gage, -SITE, -begin, -end, -count, -DA_scale, -adjustment) %>%
+    filter(site_gage != "--") %>%
+    group_by(site_gage) %>%
     summarise(start = min(begin),
               end = max(end))
   

--- a/3_filter/src/summarize_flow.R
+++ b/3_filter/src/summarize_flow.R
@@ -4,9 +4,9 @@ summarize_flow <- function(summary.samples) {
   
   summary.flow <- summary.samples %>%
     select(-siteID) %>%
-    gather(siteID, site_gage, -SITE, -begin, -end, -count, -DA_scale, -adjustment) %>%
-    filter(site_gage != "--") %>%
-    group_by(site_gage) %>%
+    gather(site_rank, siteID, -SITE, -begin, -end, -count, -DA_scale, -adjustment) %>%
+    filter(siteID != "--") %>%
+    group_by(siteID) %>%
     summarise(start = min(begin),
               end = max(end))
   

--- a/3_filter/src/summarize_sites.R
+++ b/3_filter/src/summarize_sites.R
@@ -2,32 +2,26 @@ library(yaml)
 library(dplyr)
 library(readxl)
 
-summarize_sites <- function(sample.data, site.info, min.samples) {
+summarize_sites <- function(sample.data, site.info) {
 
   summary.samples <- sample.data %>%
     group_by(SITE) %>%
     summarize(begin = min(DATE,na.rm = TRUE),
               end = max(DATE,na.rm = TRUE),
               count = n()) %>%
-    filter(count > min.samples) %>%
     arrange(desc(count)) 
   
-  # Note:  S is surface, B bottom and M middle.
-  
-  summary.samples$main_site <- regmatches(summary.samples$SITE, regexpr("[A-Za-z]{2}-[0-9]{2}", summary.samples$SITE)) 
-  
-  summary.samples$depth_code <- gsub(pattern = "[A-Za-z]{2}-[0-9]{2}",replacement = "", summary.samples$SITE)
-  
-  flow.info <- select(site.info, Site, siteID = STAID,
+flow.info <- select(site.info, Site, siteID = STAID,
                       Q_1 = `USGS Primary Flow Site to use`,
                       Q_2 = `USGS Secondary Flow Site to use`,
                       Q_3 = `USGS Tertiary Flow Site to use`,
+                      Q_4 = `USGS Quaternary Flow Site to use`,
                       DA_scale = `DA scale factor`,
                       adjustment = `Flow adjustments to make`)
   
   summary.sites <- summary.samples %>%
-    left_join(flow.info, by=c("main_site"="Site")) %>%
-    filter(!is.na(siteID)) 
+    left_join(flow.info, by=c("SITE"="Site"))%>%
+    filter(Q_1 != "--") 
   
   return(summary.sites)
 }

--- a/4_discharge/src/get_flow.R
+++ b/4_discharge/src/get_flow.R
@@ -5,6 +5,7 @@ get_flow <- function(summary.flow){
   all_flow <- readNWISdv(summary.flow$siteID,"00060",
                          startDate = min(summary.flow$start),
                          endDate = max(summary.flow$end))
+  all_flow <- renameNWISColumns(all_flow)
   
   return(all_flow)
   

--- a/5_adjust_discharge.yml
+++ b/5_adjust_discharge.yml
@@ -4,15 +4,15 @@ include:
   - 4_discharge.yml
 
 packages:
-  - 
+  - dplyr
 
 sources:
   - 5_adjust_discharge/src/adjust_discharge_data.R
 
 targets:
   5_adjust_discharge:
-  depends: 
-  - adjusted_discharge
+    depends: 
+      - adjusted_discharge
 
-adjusted_discharge: 
-  command: adjust_discharge_data(flow, summary.samples)
+  adjusted_discharge: 
+    command: adjust_discharge_data(flow, summary.samples)

--- a/5_adjust_discharge.yml
+++ b/5_adjust_discharge.yml
@@ -15,4 +15,4 @@ targets:
       - adjusted_discharge
 
   adjusted_discharge: 
-    command: adjust_discharge_data(flow, summary.samples)
+    command: adjust_discharge_data(flow, summary_sites)

--- a/5_adjust_discharge.yml
+++ b/5_adjust_discharge.yml
@@ -1,0 +1,18 @@
+target_default: 5_adjust_discharge
+
+include:
+  - 4_discharge.yml
+
+packages:
+  - 
+
+sources:
+  - 5_adjust_discharge/src/adjust_discharge_data.R
+
+targets:
+  5_adjust_discharge:
+  depends: 
+  - adjusted_discharge
+
+adjusted_discharge: 
+  command: adjust_discharge_data(flow, summary.samples)

--- a/5_adjust_discharge/src/adjust_discharge_data.R
+++ b/5_adjust_discharge/src/adjust_discharge_data.R
@@ -1,0 +1,62 @@
+adjust_discharge_data <- function(flow.dat, site.dat) {
+  
+  site.dat$rules <- site.dat$adjustment
+  site.dat$rules[grep('scaling', site.dat$rules, ignore.case = TRUE)] <- 'scale'
+  site.dat$rules[grep('regression', site.dat$rules, ignore.case = TRUE)] <- 'regression'
+  site.dat$rules[grep('interpolation', site.dat$rules, ignore.case = TRUE)] <- 'interpolate'
+  
+  flow.revised <- list()
+  sites <- site.dat$Q_1
+  for (i in 1:length(sites)) {
+    
+    if (site.dat$rules[i] == "As is") {
+      flow <- subset(flow.dat, site_no == sites[i])
+      flow$sample_site <- site.dat$SITE[i]
+      flow.revised[i] <- flow
+      next
+    }
+    
+    if (site.dat$rules[i] == "scale") {
+      flow <- subset(flow.dat, site_no == sites[i])
+      flow$Flow <- site.dat$DA_scale*flow$Flow
+      flow$sample_site <- site.dat$SITE[i]
+      flow.revised[i] <- flow
+    }
+    
+    if (site.dat$rules[i] == 'interpolate') {
+      flow1 <- subset(flow.dat, site_no == site.dat$Q_1[i])
+      flow2 <- subset(flow.dat, site_no == site.dat$Q_2[i])
+      flow <- full_join(flow1, flow2, by = 'Date') %>%
+        arrange(Date) %>%
+        rowwise %>%
+        mutate(Flow = median(c(Flow.x, Flow.y))) %>%
+        filter(Date >= site.dat$begin[i])
+      
+      
+      if (anyNA(flow$Flow)) {
+        # find which var has data
+        flow.temp <- subset(flow, is.na(flow$Flow))
+        
+        if (anyNA(flow.temp$Flow.x)) {
+          mod <- lm(Flow ~ Flow.y, data = flow)
+          flow$Flow[is.na(flow$Flow)] <- as.numeric(predict(mod, newdata = flow.temp))
+          flow$Flow_cd <- flow$Flow_cd.y
+        } else {
+          mod <- lm(Flow ~ Flow.x, data = flow)
+          flow$Flow[is.na(flow$Flow)] <- as.numeric(predict(mod, newdata = flow.temp))
+          flow$Flow_cd <- flow$Flow_cd.x
+        }
+      }
+      
+      flow <- flow %>%
+        select(Date, Flow) %>%
+        mutate(agency_cd = "USGS") %>%
+        mutate(site_no = site.dat$Q_1[i]) %>%
+        mutate(sample_site = site.dat$SITE[i]) %>%
+        select(agency_cd, site_no, Date, Flow, Flow_cd, sample_site)
+    }
+  
+        
+    }
+  
+}

--- a/5_adjust_discharge/src/adjust_discharge_data.R
+++ b/5_adjust_discharge/src/adjust_discharge_data.R
@@ -224,4 +224,5 @@ adjust_discharge_data <- function(flow.dat, site.dat) {
   }
   
   flow.revised.out <- rbindlist(flow.revised)
+  return(flow.revised.out)
 }

--- a/5_adjust_discharge/src/adjust_discharge_data.R
+++ b/5_adjust_discharge/src/adjust_discharge_data.R
@@ -1,3 +1,5 @@
+library(dplyr)
+
 adjust_discharge_data <- function(flow.dat, site.dat) {
   
   site.dat$rules <- site.dat$adjustment

--- a/5_adjust_discharge/src/adjust_discharge_data.R
+++ b/5_adjust_discharge/src/adjust_discharge_data.R
@@ -63,6 +63,7 @@ adjust_discharge_data <- function(flow.dat, site.dat) {
       flow$Flow <- site.dat$DA_scale[i]*flow$Flow
       flow$sample_site <- site.dat$SITE[i]
       flow.revised[[i]] <- flow
+      next
     }
     
     # for interpolation, take the median (or mean) value
@@ -173,6 +174,7 @@ adjust_discharge_data <- function(flow.dat, site.dat) {
         select(agency_cd, site_no, Date, Flow, Flow_cd, sample_site)
       
       flow.revised[[i]] <- flow.regressed
+      next
     }
     
     if (site.dat$SITE[i] == 'OH-01') {

--- a/5_merge.yml
+++ b/5_merge.yml
@@ -1,7 +1,7 @@
 target_default: 5_merge
 
 include:
-  - 4_discharge.yml
+  - 5_adjust_discharge.yml
 
 packages:
   - EGRET
@@ -17,7 +17,7 @@ targets:
       - 5_merge/doc/data_checks.pdf
   
   merged_flow: 
-    command: merge_sample_flow(sample_data, summary_sites, flow, save.eLists.in='5_merge/out')
+    command: merge_sample_flow(sample_data, summary_sites, adjusted_discharge, save.eLists.in='5_merge/out')
   
   5_merge/doc/data_checks.pdf:
     command: plot_eLists(merged_flow, '5_merge/out', target_name)

--- a/5_merge/src/merge_sample_flow.R
+++ b/5_merge/src/merge_sample_flow.R
@@ -3,7 +3,7 @@ library(dplyr)
 
 merge_sample_flow <- function(all.samples, site.summary, all.flow, save.eLists.in){
 
-  min.samples <- 50
+  #min.samples <- 50
   
   dir.create(save.eLists.in, showWarnings = FALSE, recursive = TRUE)
   
@@ -23,8 +23,12 @@ merge_sample_flow <- function(all.samples, site.summary, all.flow, save.eLists.i
   for(i in site.summary$SITE){
     
     sample.data <- filter(all.samples, SITE == i)
-    flow_site <- site.summary$siteID[which(site.summary$SITE == i)]
-    flow <- filter(all.flow, site_no == flow_site)
+    #flow_site <- site.summary$siteID[which(site.summary$SITE == i)]
+    flow <- all.flow %>%
+      filter(sample_site == i) %>%
+      select(-sample_site)
+    
+    # don't think we need the if statement below, since all sites now have flow
     if(nrow(flow) == 0){
       master_list <- bind_rows(master_list, 
                                data.frame(id = paste(i, params$paramShortName, sep="_"),


### PR DESCRIPTION
This PR fixes the following issues we discussed: 1) taking the mean of repeated values on a given day, 2) pulls flow from all gages that are needed for the 20 QW sites, 3) adjusts flow according the rules in Michele's spreadsheet. Flow adjustments are now done through a separate make step (e.g., has its own yml file) called '5_adjust_discharge'. I have not renamed downstream yml files yet.

I can't get the `make('adjusted_discharge')` to work - error says "no such target". What am I missing here?